### PR TITLE
Fix Trigger.dev WebSocket crash on Node 21

### DIFF
--- a/trigger.config.ts
+++ b/trigger.config.ts
@@ -2,7 +2,9 @@ import { defineConfig } from "@trigger.dev/sdk/v3";
 
 export default defineConfig({
   project: "proj_qmryethkfylqgamfxbdm",
-  runtime: "node",
+  // @supabase/realtime-js は Node 22+ の global WebSocket が必要。
+  // runtime: "node" は 21.7.3 のため createClient 時点で落ちる。
+  runtime: "node-22",
   logLevel: "log",
   // The max compute seconds a task is allowed to run. If the task run exceeds this duration, it will be stopped.
   // You can override this on an individual task.


### PR DESCRIPTION
## Summary
- Trigger.dev のデフォルト runtime（Node 21.7.3）には native WebSocket がなく、`createClient` 時点で店舗更新ジョブが落ちていた
- `runtime: \"node-22\"` に変更して Supabase realtime-js の要件を満たす

## Test plan
- [ ] PR マージ後の Trigger.dev deploy が成功する
- [ ] `update-bookstores` を手動実行して WebSocket エラーが出ない
- [ ] 店舗リストがスプレッドシートと同期される